### PR TITLE
Fix pandoc command in how-to-apply.md

### DIFF
--- a/how-to-apply.md
+++ b/how-to-apply.md
@@ -52,5 +52,5 @@ You can use our [base template](proposal-template.md) to draft your application 
 Your final proposal must be submitted to GSoC as a PDF file, so you can use Pandoc to generate one from your Markdown file:
 
 ```
-$ pandoc -f markdown -t pdf your-name.md
+$ pandoc your-name.md -o your-name.pdf
 ```


### PR DESCRIPTION
`$ pandoc -f markdown -t pdf your-name.md` spits out `Unknown writer: pdf` because it expects `latex` or `beamer` for PDF output. The fixed command uses LaTeX to generate a PDF, and I think it looks a little cleaner :)