### PR TITLE
Added the timeline link of GSoC 2020 in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,26 @@ Arduino is fully committed to creating open-source hardware and software. The Ar
 
 The issue tracker of this repository is the preferred way to communicate with us. Should you have private inquiries, send an e-mail to [summer-of-code@arduino.cc](mailto:summer-of-code@arduino.cc).
 
+## What is the Detailed Timeline for Google Summer of Code 2020(Updated)?
+
+* Now - March 31 18:00 UTC: Students submit their final proposals and proof of enrollment
+* March 31 - May 4: Mentors review proposals and select students
+* May 4: Accepted GSoC 2020 students/projects are announced
+* May 4 - 31: Community Bonding Period
+* June 1: Coding begins
+* June 29 - July 3: First evaluation period - mentors evaluate students, students evaluate *   
+  mentors
+* July 27 - 31: Second evaluation period - mentors evaluate students, students evaluate mentors
+* August 24 -31: Students wrap up their projects and submit final evaluation of their mentor
+* August 31 - September 7: Mentors submit final evaluations of students
+* September 8: Students passing GSoC 2020 are announced
+
+This information is Also available at GSoC 2020 Portal [Click Here](https://summerofcode.withgoogle.com/how-it-works/#timeline)
+
+**Don't Forget to update your Schedule of Deliverables in your project proposal** 
+
+
+
+* Open an issue in this [issue tracker](https://github.com/arduino/summer-of-code/issues) (only **one issue per student**): you can use it to ask questions and communicate with us.
+
+The issue tracker of this repository is the preferred way to communicate with us. Should you have private inquiries, send an e-mail to [summer-of-code@arduino.cc](mailto:summer-of-code@arduino.cc).

--- a/README.md
+++ b/README.md
@@ -19,24 +19,5 @@ The issue tracker of this repository is the preferred way to communicate with us
 
 ## What is the Detailed Timeline for Google Summer of Code 2020(Updated)?
 
-* Now - March 31 18:00 UTC: Students submit their final proposals and proof of enrollment
-* March 31 - May 4: Mentors review proposals and select students
-* May 4: Accepted GSoC 2020 students/projects are announced
-* May 4 - 31: Community Bonding Period
-* June 1: Coding begins
-* June 29 - July 3: First evaluation period - mentors evaluate students, students evaluate   
-  mentors
-* July 27 - 31: Second evaluation period - mentors evaluate students, students evaluate mentors
-* August 24 -31: Students wrap up their projects and submit final evaluation of their mentor
-* August 31 - September 7: Mentors submit final evaluations of students
-* September 8: Students passing GSoC 2020 are announced
-
-This information is Also available at GSoC 2020 Portal [Click Here](https://summerofcode.withgoogle.com/how-it-works/#timeline)
-
+* The information regarding the detailed timeline is available at GSoC 2020 Portal [Click Here](https://summerofcode.withgoogle.com/how-it-works/#timeline)
 **Don't Forget to update your Schedule of Deliverables(if any) in your project proposal** 
-
-
-
-* Open an issue in this [issue tracker](https://github.com/arduino/summer-of-code/issues) (only **one issue per student**): you can use it to ask questions and communicate with us.
-
-The issue tracker of this repository is the preferred way to communicate with us. Should you have private inquiries, send an e-mail to [summer-of-code@arduino.cc](mailto:summer-of-code@arduino.cc).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Arduino is fully committed to creating open-source hardware and software. The Ar
 ## What is the Detailed Timeline for Google Summer of Code 2020 ?
 
 * The information regarding the detailed timeline is available at GSoC 2020 Portal [Click Here](https://summerofcode.withgoogle.com/how-it-works/#timeline)
-**Don't Forget to update your Schedule of Deliverables(if any) in your project proposal** 
+**Don't Forget to update your Schedule of Deliverables (if any) in your project proposal** 
 
 ## How can I apply?
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Arduino is fully committed to creating open-source hardware and software. The Ar
 
 The issue tracker of this repository is the preferred way to communicate with us. Should you have private inquiries, send an e-mail to [summer-of-code@arduino.cc](mailto:summer-of-code@arduino.cc).
 
-## What is the Detailed Timeline for Google Summer of Code 2020(Updated)?
+## What is the Detailed Timeline for Google Summer of Code 2020 ?
 
 * The information regarding the detailed timeline is available at GSoC 2020 Portal [Click Here](https://summerofcode.withgoogle.com/how-it-works/#timeline)
 **Don't Forget to update your Schedule of Deliverables(if any) in your project proposal** 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Arduino is applying as a mentoring organization for GSoC 2020. This repository s
 
 Arduino is fully committed to creating open-source hardware and software. The Arduino community is one of the largest tech communities in the world, and our collaborative efforts have a big impact on democratizing electronics. Working with us is a great opportunity to work on code that is used daily by millions of people. The quality of the Arduino hardware, as well as the Arduino software and libraries, is what glued this community: will you work with us to improve all this?
 
+## What is the Detailed Timeline for Google Summer of Code 2020 ?
+
+* The information regarding the detailed timeline is available at GSoC 2020 Portal [Click Here](https://summerofcode.withgoogle.com/how-it-works/#timeline)
+**Don't Forget to update your Schedule of Deliverables(if any) in your project proposal** 
+
 ## How can I apply?
 
 * Read [the application guide](how-to-apply.md) and the [ideas list](ideas.md).
@@ -17,7 +22,4 @@ Arduino is fully committed to creating open-source hardware and software. The Ar
 
 The issue tracker of this repository is the preferred way to communicate with us. Should you have private inquiries, send an e-mail to [summer-of-code@arduino.cc](mailto:summer-of-code@arduino.cc).
 
-## What is the Detailed Timeline for Google Summer of Code 2020 ?
 
-* The information regarding the detailed timeline is available at GSoC 2020 Portal [Click Here](https://summerofcode.withgoogle.com/how-it-works/#timeline)
-**Don't Forget to update your Schedule of Deliverables(if any) in your project proposal** 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The issue tracker of this repository is the preferred way to communicate with us
 * May 4: Accepted GSoC 2020 students/projects are announced
 * May 4 - 31: Community Bonding Period
 * June 1: Coding begins
-* June 29 - July 3: First evaluation period - mentors evaluate students, students evaluate *   
+* June 29 - July 3: First evaluation period - mentors evaluate students, students evaluate   
   mentors
 * July 27 - 31: Second evaluation period - mentors evaluate students, students evaluate mentors
 * August 24 -31: Students wrap up their projects and submit final evaluation of their mentor

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The issue tracker of this repository is the preferred way to communicate with us
 
 This information is Also available at GSoC 2020 Portal [Click Here](https://summerofcode.withgoogle.com/how-it-works/#timeline)
 
-**Don't Forget to update your Schedule of Deliverables in your project proposal** 
+**Don't Forget to update your Schedule of Deliverables(if any) in your project proposal** 
 
 
 


### PR DESCRIPTION
I have edited the Readme.md with the new timelines.
And also added the guideline for the participants so that they update the new timeline in the schedule of Deliverables in the Project
@alranel Another small contribution against [#99](https://github.com/arduino/summer-of-code/issues/99)